### PR TITLE
theme 0.1 fonts & colors

### DIFF
--- a/src/scss/neumorphism/_variables.scss
+++ b/src/scss/neumorphism/_variables.scss
@@ -8,13 +8,11 @@ $enable-grid-classes:       true;
 $enable-print-styles:       true;
 
 // Color scheme
-
-$default:       #262833;
-// $primary:       #e6e7ee;
-$primary:       #FFF1E5;
-$dark-primary:       #ccbeb3;
-//$secondary:     #2D4CC8;
-$secondary: #80deea;
+// (updated colors from the new 2022 design system)
+$default:    #0B0B14;
+$primary:    #FDF8F2;
+$light-gray: #A9A9B2;
+$secondary:  #757684;
 
 // Generic colors
 $blue:    #0056B3;
@@ -35,13 +33,12 @@ $gray-200: #fafbfe;
 $gray-300: #e6e7ee;
 $gray-400: #D1D9E6;
 $gray-500: #b1bcce;
-$gray-600: #93a5be;   
-$gray-700: #66799e;   
-$gray-800: #525480;   
+$gray-600: #93a5be;
+$gray-700: #66799e;
+$gray-800: #525480;
 $gray-900: #44476A;
-//$dark    : #31344b;
-$dark    : #000000;
-$black   : #262833;
+$dark    : #0B0B14;
+$black   : #0B0B14;
 
 
 $grays: ();
@@ -63,8 +60,7 @@ $info:          $teal;
 $warning:       $yellow;
 $danger:        $red;
 $gray:          $gray-900;
-$light:         $dark-primary;
-//$soft:          $gray-300;
+$light:         $light-gray;
 $soft:          $primary;
 $dark:          $dark;
 
@@ -119,7 +115,7 @@ $brand-colors: map-merge((
   "twitch":       $twitch,
   "paypal":       $paypal,
   "behance":      $behance,
-  "reddit" :      $reddit,  
+  "reddit" :      $reddit,
   "github":       $github
 ), $brand-colors);
 
@@ -235,7 +231,7 @@ $border-width-md:             0.125rem;
 $border-width-lg:             0.25rem;
 $border-width-xl:             0.375rem;
 $border-color-white:          $white;
-$border-color:                $dark-primary;
+$border-color:                $light-gray;
 
 $border-radius:               .55rem;
 $border-radius-xl:            .95rem;
@@ -498,7 +494,7 @@ $input-muted-bg:                        $gray-100;
 
 $input-color:                           $body-color;
 //$input-border-color:                    $light;
-$input-border-color:                    $dark-primary;
+$input-border-color:                    $light-gray;
 $input-border-width:                    $border-width ;
 
 $input-focus-bg:                        $primary;
@@ -618,7 +614,7 @@ $dropdown-spacer:                   .825rem;
 $dropdown-font-size:                $font-size-sm;
 $dropdown-bg:                       $primary;
 $dropdown-border-width:             $border-width;
-$dropdown-border-color:             $dark-primary;
+$dropdown-border-color:             $light-gray;
 $dropdown-border-radius:            $border-radius;
 $dropdown-item-color:               $body-color;
 $dropdown-item-font-weight:         $font-weight-light;

--- a/src/scss/neumorphism/_variables.scss
+++ b/src/scss/neumorphism/_variables.scss
@@ -260,9 +260,9 @@ $transition-tabs:             all 0.2s;
 
 
 // Fonts
+$font-family-base:            'Neue Haas Grotesk Text', "Helvetica Neue", Helvetica, Arial,  sans-serif;
+$font-family-headers:         'Neue Haas Grotesk Display', "Helvetica Neue", Helvetica, Arial, sans-serif;
 $fontawesome-webfonts-path:   '../vendor/font-awesome/webfonts';
-$font-family-base:            'Open Sans', sans-serif;
-$font-family-headers:         'Exo 2', sans-serif;
 $font-awesome-5:              'Font Awesome 5 Free';
 $font-size-base:              1rem; // Assumes the browser default, typically `16px`
 $font-size-xxl:               ($font-size-base * 2);
@@ -288,8 +288,8 @@ $h6-font-size:                $font-size-base;
 
 $headings-margin-bottom:      ($spacer / 2);
 $headings-font-family:        inherit;
-$headings-font-weight:        $font-weight-normal;
-$headings-line-height:        1.3;
+$headings-font-weight:        $font-weight-bold;
+$headings-line-height:        1.16;
 $headings-color:              $dark;
 
 $heading-letter-spacing:      .025em;
@@ -311,7 +311,7 @@ $heading-section-text-transform:      uppercase;
 $display1-size:               5rem;
 $display2-size:               3.5rem;
 $display3-size:               2.5rem;
-$display4-size:               1.875rem  ;
+$display4-size:               1.875rem;
 
 $display1-weight:             $font-weight-bold;
 $display2-weight:             $font-weight-bold;


### PR DESCRIPTION
Pull new design-system fonts and colors into Bootstrap theme.

Note – using hex colors for now to keep it simple / consistent with rest of Bootstrap theme.